### PR TITLE
通过 Scheduler 找到 CookieClientManager

### DIFF
--- a/nonebot_bison/admin_page/api.py
+++ b/nonebot_bison/admin_page/api.py
@@ -18,7 +18,7 @@ from ..utils.get_bot import get_groups
 from .token_manager import token_manager
 from ..config.db_config import SubscribeDupException
 from ..platform import site_manager, platform_manager
-from ..utils.site import CookieSite, CookieClientManager, is_cookie_client_manager
+from ..utils.site import CookieClientManager, is_cookie_client_manager
 from ..config import NoSuchUserException, NoSuchTargetException, NoSuchSubscribeException, config
 from .types import (
     Cookie,
@@ -272,8 +272,8 @@ async def del_cookie_target(platform_name: str, target: str, cookie_id: int) -> 
 
 @router.post("/cookie/validate", dependencies=[Depends(check_is_superuser)])
 async def get_cookie_valid(site_name: str, content: str) -> StatusResp:
-    site = cast(CookieSite, site_manager[site_name])
-    if await site.validate_cookie(content):
+    client_mgr = cast(CookieClientManager, scheduler_dict[site_manager[site_name]].client_mgr)
+    if await client_mgr.validate_cookie(content):
         return StatusResp(ok=True, msg="")
     else:
         return StatusResp(ok=False, msg="")

--- a/nonebot_bison/admin_page/api.py
+++ b/nonebot_bison/admin_page/api.py
@@ -12,6 +12,7 @@ from fastapi.security.oauth2 import OAuth2PasswordBearer
 from ..types import WeightConfig
 from ..apis import check_sub_target
 from .jwt import load_jwt, pack_jwt
+from ..scheduler import scheduler_dict
 from ..types import Target as T_Target
 from ..utils.get_bot import get_groups
 from .token_manager import token_manager
@@ -231,7 +232,7 @@ async def get_cookie(site_name: str = None, target: str = None) -> list[Cookie]:
 
 @router.post("/cookie", dependencies=[Depends(check_is_superuser)])
 async def add_cookie(site_name: str, content: str) -> StatusResp:
-    client_mgr = cast(CookieClientManager, site_manager[site_name].client_mgr)
+    client_mgr = cast(CookieClientManager, scheduler_dict[site_manager[site_name]].client_mgr)
     await client_mgr.add_user_cookie(content)
     return StatusResp(ok=True, msg="")
 

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -78,7 +78,7 @@ class BilibiliClientManager(CookieClientManager):
 
     @override
     async def refresh_client(self):
-        self.refresh_anonymous_cookie()
+        await self._refresh_anonymous_cookie()
         logger.debug("刷新B站客户端的cookie")
 
     @override

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -49,8 +49,8 @@ class BilibiliClientManager(CookieClientManager):
     async def _generate_anonymous_cookie(self) -> CookieModel:
         cookies = await self._get_cookies()
         cookie = CookieModel(
-            cookie_name=f"{self._site.name} anonymous",
-            site_name=self._site.name,
+            cookie_name=f"{self._site_name} anonymous",
+            site_name=self._site_name,
             content=json.dumps(self._gen_json_cookie(cookies)),
             is_universal=True,
             is_anonymous=True,

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -10,8 +10,8 @@ from playwright.async_api import Cookie
 
 from nonebot_bison.utils import Site, http_client
 
+from ...utils.site import CookieClientManager
 from ...config.db_model import Cookie as CookieModel
-from ...utils.site import CookieSite, CookieClientManager
 
 if TYPE_CHECKING:
     from .platforms import Bilibili
@@ -23,6 +23,8 @@ B = TypeVar("B", bound="Bilibili")
 
 
 class BilibiliClientManager(CookieClientManager):
+
+    _default_cookie_cd: int = timedelta(seconds=120)
 
     @classmethod
     async def _get_cookies(self) -> list[Cookie]:
@@ -73,13 +75,12 @@ class BilibiliClientManager(CookieClientManager):
         return http_client()
 
 
-class BilibiliSite(CookieSite):
+class BilibiliSite(Site):
     name = "bilibili.com"
     schedule_setting = {"seconds": 60}
     schedule_type = "interval"
     client_mgr = BilibiliClientManager
     require_browser = True
-    default_cookie_cd: int = timedelta(seconds=120)
 
 
 class BililiveSite(Site):

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -47,12 +47,12 @@ class BilibiliClientManager(CookieClientManager):
 
     @classmethod
     @override
-    async def _generate_anonymous_cookie(cls) -> CookieModel:
-        cookies = await cls._get_cookies()
+    async def _generate_anonymous_cookie(self) -> CookieModel:
+        cookies = await self._get_cookies()
         cookie = CookieModel(
-            cookie_name=f"{cls._site_name} anonymous",
-            site_name=cls._site_name,
-            content=json.dumps(cls._gen_json_cookie(cookies)),
+            cookie_name=f"{self._site_name} anonymous",
+            site_name=self._site_name,
+            content=json.dumps(self._gen_json_cookie(cookies)),
             is_universal=True,
             is_anonymous=True,
             last_usage=datetime.now(),

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -23,13 +23,8 @@ B = TypeVar("B", bound="Bilibili")
 
 
 class BilibiliClientManager(CookieClientManager):
-    _client: AsyncClient
     _inited: bool = False
-
     _site_name: str = "bilibili.com"
-
-    def __init__(self) -> None:
-        self._client = http_client()
 
     @classmethod
     async def _get_cookies(self) -> list[Cookie]:
@@ -42,15 +37,6 @@ class BilibiliClientManager(CookieClientManager):
             cookies = await page.context.cookies()
 
         return cookies
-
-    async def _reset_client_cookies(self, cookies: list[Cookie]):
-        for cookie in cookies:
-            self._client.cookies.set(
-                name=cookie.get("name", ""),
-                value=cookie.get("value", ""),
-                domain=cookie.get("domain", ""),
-                path=cookie.get("path", "/"),
-            )
 
     @classmethod
     def _gen_json_cookie(self, cookies: list[Cookie]):

--- a/nonebot_bison/platform/bilibili/scheduler.py
+++ b/nonebot_bison/platform/bilibili/scheduler.py
@@ -23,8 +23,6 @@ B = TypeVar("B", bound="Bilibili")
 
 
 class BilibiliClientManager(CookieClientManager):
-    _inited: bool = False
-    _site_name: str = "bilibili.com"
 
     @classmethod
     async def _get_cookies(self) -> list[Cookie]:
@@ -45,13 +43,12 @@ class BilibiliClientManager(CookieClientManager):
             cookie_dict[cookie.get("name", "")] = cookie.get("value", "")
         return cookie_dict
 
-    @classmethod
     @override
     async def _generate_anonymous_cookie(self) -> CookieModel:
         cookies = await self._get_cookies()
         cookie = CookieModel(
-            cookie_name=f"{self._site_name} anonymous",
-            site_name=self._site_name,
+            cookie_name=f"{self._site.name} anonymous",
+            site_name=self._site.name,
             content=json.dumps(self._gen_json_cookie(cookies)),
             is_universal=True,
             is_anonymous=True,

--- a/nonebot_bison/platform/rss.py
+++ b/nonebot_bison/platform/rss.py
@@ -10,14 +10,14 @@ from ..post import Post
 from .platform import NewMessage
 from ..types import Target, RawPost
 from ..utils import text_similarity
-from ..utils.site import CookieSite, CookieClientManager
+from ..utils.site import Site, create_cookie_client_manager
 
 
-class RssSite(CookieSite):
+class RssSite(Site):
     name = "rss"
     schedule_type = "interval"
     schedule_setting = {"seconds": 30}
-    client_mgr = CookieClientManager
+    client_mgr = create_cookie_client_manager(name)
 
 
 class RssPost(Post):

--- a/nonebot_bison/platform/rss.py
+++ b/nonebot_bison/platform/rss.py
@@ -10,14 +10,14 @@ from ..post import Post
 from .platform import NewMessage
 from ..types import Target, RawPost
 from ..utils import text_similarity
-from ..utils.site import CookieSite, create_cookie_client_manager
+from ..utils.site import CookieSite, CookieClientManager
 
 
 class RssSite(CookieSite):
     name = "rss"
     schedule_type = "interval"
     schedule_setting = {"seconds": 30}
-    client_mgr = create_cookie_client_manager("rss")
+    client_mgr = CookieClientManager
 
 
 class RssPost(Post):

--- a/nonebot_bison/platform/weibo.py
+++ b/nonebot_bison/platform/weibo.py
@@ -13,7 +13,7 @@ from bs4 import BeautifulSoup as bs
 from ..post import Post
 from .platform import NewMessage
 from ..utils import http_client, text_fletten
-from ..utils.site import CookieSite, CookieClientManager
+from ..utils.site import Site, CookieClientManager
 from ..types import Tag, Target, RawPost, ApiError, Category
 
 _HEADER = {
@@ -55,11 +55,11 @@ class WeiboClientManager(CookieClientManager):
         return text_fletten(f"weibo: [{name[:10]}]")
 
 
-class WeiboSite(CookieSite):
+class WeiboSite(Site):
     name = "weibo.com"
     schedule_type = "interval"
     schedule_setting = {"seconds": 3}
-    client_mgr = CookieClientManager
+    client_mgr = WeiboClientManager
 
 
 class Weibo(NewMessage):

--- a/nonebot_bison/platform/weibo.py
+++ b/nonebot_bison/platform/weibo.py
@@ -13,8 +13,8 @@ from bs4 import BeautifulSoup as bs
 from ..post import Post
 from .platform import NewMessage
 from ..utils import http_client, text_fletten
+from ..utils.site import CookieSite, CookieClientManager
 from ..types import Tag, Target, RawPost, ApiError, Category
-from ..utils.site import CookieSite, create_cookie_client_manager
 
 _HEADER = {
     "accept": (
@@ -40,7 +40,7 @@ class WeiboSite(CookieSite):
     name = "weibo.com"
     schedule_type = "interval"
     schedule_setting = {"seconds": 3}
-    client_mgr = create_cookie_client_manager(name)
+    client_mgr = CookieClientManager
     default_cookie_cd: int = timedelta(seconds=15)
 
     @classmethod

--- a/nonebot_bison/scheduler/manager.py
+++ b/nonebot_bison/scheduler/manager.py
@@ -35,7 +35,7 @@ async def init_scheduler():
     for site, target_list in _schedule_class_dict.items():
         if is_cookie_client_manager(site.client_mgr):
             client_mgr = cast(CookieClientManager, site.client_mgr)
-            await client_mgr.refresh_anonymous_cookie()
+            await client_mgr.refresh_client()
         if not plugin_config.bison_use_browser and site.require_browser:
             logger.warning(f"{site.name} requires browser, it will not schedule.")
             continue

--- a/nonebot_bison/scheduler/manager.py
+++ b/nonebot_bison/scheduler/manager.py
@@ -33,9 +33,6 @@ async def init_scheduler():
         else:
             _schedule_class_platform_dict[site].append(platform_name)
     for site, target_list in _schedule_class_dict.items():
-        if is_cookie_client_manager(site.client_mgr):
-            client_mgr = cast(CookieClientManager, site.client_mgr)
-            await client_mgr.refresh_client()
         if not plugin_config.bison_use_browser and site.require_browser:
             logger.warning(f"{site.name} requires browser, it will not schedule.")
             continue
@@ -47,6 +44,9 @@ async def init_scheduler():
             )
         platform_name_list = _schedule_class_platform_dict[site]
         scheduler_dict[site] = Scheduler(site, schedulable_args, platform_name_list)
+        if is_cookie_client_manager(site.client_mgr):
+            client_mgr = cast(CookieClientManager, scheduler_dict[site].client_mgr)
+            await client_mgr.refresh_client()
     config.register_add_target_hook(handle_insert_new_target)
     config.register_delete_target_hook(handle_delete_target)
 

--- a/nonebot_bison/scheduler/scheduler.py
+++ b/nonebot_bison/scheduler/scheduler.py
@@ -1,4 +1,3 @@
-from typing import cast
 from dataclasses import dataclass
 from collections import defaultdict
 
@@ -13,7 +12,7 @@ from ..send import send_msgs
 from ..types import Target, SubUnit
 from ..platform import platform_manager
 from ..utils import Site, ProcessContext
-from ..utils.site import CookieClientManager, SkipRequestException, is_cookie_client_manager
+from ..utils.site import SkipRequestException
 
 
 @dataclass
@@ -42,11 +41,7 @@ class Scheduler:
             raise RuntimeError(f"{self.name} not found")
         self.scheduler_config = scheduler_config
         self.scheduler_config_obj = self.scheduler_config()
-        if is_cookie_client_manager(scheduler_config.client_mgr):
-            cookie_client_mgr = cast(type[CookieClientManager], scheduler_config.client_mgr)
-            self.client_mgr = cookie_client_mgr(self.scheduler_config_obj)
-        else:
-            self.client_mgr = scheduler_config.client_mgr()
+        self.client_mgr = scheduler_config.client_mgr()
 
         self.schedulable_list = []
         self.batch_platform_name_targets_cache = defaultdict(list)

--- a/nonebot_bison/sub_manager/add_cookie.py
+++ b/nonebot_bison/sub_manager/add_cookie.py
@@ -10,8 +10,8 @@ from nonebot.adapters import Message, MessageTemplate
 
 from ..scheduler import scheduler_dict
 from ..platform import platform_manager
+from ..utils.site import CookieClientManager, is_cookie_client_manager
 from .utils import common_platform, gen_handle_cancel, only_allow_private
-from ..utils.site import CookieSite, CookieClientManager, is_cookie_client_manager
 
 
 def do_add_cookie(add_cookie: type[Matcher]):
@@ -56,8 +56,7 @@ def do_add_cookie(add_cookie: type[Matcher]):
 
     @add_cookie.got("cookie", MessageTemplate("{_prompt}"), [handle_cancel])
     async def got_cookie(state: T_State, cookie: Message = Arg()):
-        cookie_site = cast(type[CookieSite], platform_manager[state["platform"]].site)
-        client_mgr = cast(CookieClientManager, scheduler_dict[cookie_site].client_mgr)
+        client_mgr = cast(CookieClientManager, scheduler_dict[platform_manager[state["platform"]].site].client_mgr)
         cookie_text = cookie.extract_plain_text()
         if not await client_mgr.validate_cookie(cookie_text):
             await add_cookie.reject(
@@ -75,8 +74,7 @@ def do_add_cookie(add_cookie: type[Matcher]):
 
     @add_cookie.handle()
     async def add_cookie_process(state: T_State):
-        cookie_site = cast(type[CookieSite], platform_manager[state["platform"]].site)
-        client_mgr = cast(CookieClientManager, scheduler_dict[cookie_site].client_mgr)
+        client_mgr = cast(CookieClientManager, scheduler_dict[platform_manager[state["platform"]].site].client_mgr)
         new_cookie = await client_mgr.add_user_cookie(state["cookie"], state["cookie_name"])
         await add_cookie.finish(
             f"已添加 Cookie: {new_cookie.cookie_name} 到平台 {state['platform']}"

--- a/nonebot_bison/sub_manager/add_cookie.py
+++ b/nonebot_bison/sub_manager/add_cookie.py
@@ -8,6 +8,7 @@ from nonebot.params import Arg, ArgPlainText
 from nonebot.adapters.onebot.v11 import MessageEvent
 from nonebot.adapters import Message, MessageTemplate
 
+from ..scheduler import scheduler_dict
 from ..platform import platform_manager
 from .utils import common_platform, gen_handle_cancel, only_allow_private
 from ..utils.site import CookieSite, CookieClientManager, is_cookie_client_manager
@@ -46,7 +47,6 @@ def do_add_cookie(add_cookie: type[Matcher]):
             await add_cookie.finish("已中止添加cookie")
         elif platform in platform_manager:
             state["platform"] = platform
-            state["site"] = cast(CookieSite, platform_manager[platform].site)
         else:
             await add_cookie.reject("平台输入错误")
 
@@ -74,7 +74,8 @@ def do_add_cookie(add_cookie: type[Matcher]):
 
     @add_cookie.handle()
     async def add_cookie_process(state: T_State):
-        client_mgr = cast(CookieClientManager, platform_manager[state["platform"]].site.client_mgr)
+        cookie_site = cast(type[CookieSite], platform_manager[state["platform"]].site)
+        client_mgr = cast(CookieClientManager, scheduler_dict[cookie_site].client_mgr)
         new_cookie = await client_mgr.add_user_cookie(state["cookie"], state["cookie_name"])
         await add_cookie.finish(
             f"已添加 Cookie: {new_cookie.cookie_name} 到平台 {state['platform']}"

--- a/nonebot_bison/sub_manager/add_cookie.py
+++ b/nonebot_bison/sub_manager/add_cookie.py
@@ -57,13 +57,14 @@ def do_add_cookie(add_cookie: type[Matcher]):
     @add_cookie.got("cookie", MessageTemplate("{_prompt}"), [handle_cancel])
     async def got_cookie(state: T_State, cookie: Message = Arg()):
         cookie_site = cast(type[CookieSite], platform_manager[state["platform"]].site)
+        client_mgr = cast(CookieClientManager, scheduler_dict[cookie_site].client_mgr)
         cookie_text = cookie.extract_plain_text()
-        if not await cookie_site.validate_cookie(cookie_text):
+        if not await client_mgr.validate_cookie(cookie_text):
             await add_cookie.reject(
                 "无效的 Cookie，请检查后重新输入，详情见https://nonebot-bison.netlify.app/usage/cookie.html"
             )
         try:
-            cookie_name = await cookie_site.get_cookie_name(cookie_text)
+            cookie_name = await client_mgr.get_cookie_name(cookie_text)
             state["cookie"] = cookie_text
             state["cookie_name"] = cookie_name
         except JSONDecodeError as e:

--- a/nonebot_bison/utils/site.py
+++ b/nonebot_bison/utils/site.py
@@ -60,7 +60,7 @@ class CookieClientManager(ClientManager):
         )
 
     @classmethod
-    async def refresh_anonymous_cookie(cls):
+    async def _refresh_anonymous_cookie(cls):
         """更新已有的匿名cookie，若不存在则添加"""
         existing_anonymous_cookies = await config.get_cookie(cls._site_name, is_anonymous=True)
         if existing_anonymous_cookies:
@@ -135,7 +135,7 @@ class CookieClientManager(ClientManager):
         return http_client()
 
     async def refresh_client(self):
-        self.refresh_anonymous_cookie()
+        await self._refresh_anonymous_cookie()
 
 
 def is_cookie_client_manager(manger: type[ClientManager]) -> bool:

--- a/nonebot_bison/utils/site.py
+++ b/nonebot_bison/utils/site.py
@@ -43,16 +43,13 @@ class DefaultClientManager(ClientManager):
 
 
 class CookieClientManager(ClientManager):
-    _site_name: str  # 绑定的 site_name，需要使用 create_cookie_client_manager 创建 Client_mgr 时绑定
-
     def __init__(self, site: "Site") -> None:
         self._site = site
 
-    @classmethod
-    async def _generate_anonymous_cookie(cls) -> Cookie:
+    async def _generate_anonymous_cookie(self) -> Cookie:
         return Cookie(
-            cookie_name=f"{cls._site_name} anonymous",
-            site_name=cls._site_name,
+            cookie_name=f"{self._site.name} anonymous",
+            site_name=self._site.name,
             content="{}",
             is_universal=True,
             is_anonymous=True,
@@ -62,28 +59,26 @@ class CookieClientManager(ClientManager):
             status="",
         )
 
-    @classmethod
-    async def _refresh_anonymous_cookie(cls):
+    async def _refresh_anonymous_cookie(self):
         """更新已有的匿名cookie，若不存在则添加"""
-        existing_anonymous_cookies = await config.get_cookie(cls._site_name, is_anonymous=True)
+        existing_anonymous_cookies = await config.get_cookie(self._site.name, is_anonymous=True)
         if existing_anonymous_cookies:
             for cookie in existing_anonymous_cookies:
-                new_anonymous_cookie = await cls._generate_anonymous_cookie()
+                new_anonymous_cookie = await self._generate_anonymous_cookie()
                 new_anonymous_cookie.id = cookie.id  # 保持原有的id
                 await config.update_cookie(new_anonymous_cookie)
         else:
-            new_anonymous_cookie = await cls._generate_anonymous_cookie()
+            new_anonymous_cookie = await self._generate_anonymous_cookie()
             await config.add_cookie(new_anonymous_cookie)
 
-    @classmethod
-    async def add_user_cookie(cls, content: str, cookie_name: str | None = None) -> Cookie:
+    async def add_user_cookie(self, content: str, cookie_name: str | None = None) -> Cookie:
         """添加用户 cookie"""
         from ..platform import site_manager
 
-        cookie_site = cast(type[CookieSite], site_manager[cls._site_name])
+        cookie_site = cast(type[CookieSite], site_manager[self._site.name])
         if not await cookie_site.validate_cookie(content):
             raise ValueError()
-        cookie = Cookie(site_name=cls._site_name, content=content)
+        cookie = Cookie(site_name=self._site.name, content=content)
         cookie.cookie_name = cookie_name if cookie_name else await cookie_site.get_cookie_name(content)
         cookie.cd = cookie_site.default_cookie_cd
         cookie_id = await config.add_cookie(cookie)
@@ -106,7 +101,7 @@ class CookieClientManager(ClientManager):
 
     async def _choose_cookie(self, target: Target | None) -> Cookie:
         """选择 cookie 的具体算法"""
-        cookies = await config.get_cookie(self._site_name, target)
+        cookies = await config.get_cookie(self._site.name, target)
         cookies = (cookie for cookie in cookies if cookie.last_usage + cookie.cd < datetime.now())
         cookie = min(cookies, key=lambda x: x.last_usage)
         return cookie
@@ -116,9 +111,9 @@ class CookieClientManager(ClientManager):
         client = http_client()
         cookie = await self._choose_cookie(target)
         if cookie.is_universal:
-            logger.trace(f"平台 {self._site_name} 未获取到用户cookie, 使用匿名cookie")
+            logger.trace(f"平台 {self._site.name} 未获取到用户cookie, 使用匿名cookie")
         else:
-            logger.trace(f"平台 {self._site_name} 获取到用户cookie: {cookie.id}")
+            logger.trace(f"平台 {self._site.name} 获取到用户cookie: {cookie.id}")
 
         return await self._assemble_client(client, cookie)
 
@@ -143,15 +138,6 @@ class CookieClientManager(ClientManager):
 
 def is_cookie_client_manager(manger: type[ClientManager]) -> bool:
     return issubclass(manger, CookieClientManager)
-
-
-def create_cookie_client_manager(site_name: str) -> type[CookieClientManager]:
-    """创建一个平台特化的 CookieClientManger"""
-    return type(
-        "CookieClientManager",
-        (CookieClientManager,),
-        {"_site_name": site_name},
-    )
 
 
 class Site(metaclass=RegistryMeta, base=True):

--- a/nonebot_bison/utils/site.py
+++ b/nonebot_bison/utils/site.py
@@ -178,10 +178,6 @@ def create_cookie_client_manager(site_name: str) -> type[CookieClientManager]:
     )
 
 
-class CookieSite(Site):
-    pass
-
-
 def anonymous_site(schedule_type: Literal["date", "interval", "cron"], schedule_setting: dict) -> type[Site]:
     return type(
         "AnonymousSite",

--- a/nonebot_bison/utils/site.py
+++ b/nonebot_bison/utils/site.py
@@ -44,10 +44,7 @@ class DefaultClientManager(ClientManager):
 
 class CookieClientManager(ClientManager):
     _default_cookie_cd: int = timedelta(seconds=15)
-
-    def __init__(self, site: "Site") -> None:
-        self._site = site
-        self._site_name = site.name
+    _site_name: str = ""
 
     async def _generate_anonymous_cookie(self) -> Cookie:
         return Cookie(

--- a/nonebot_bison/utils/site.py
+++ b/nonebot_bison/utils/site.py
@@ -45,6 +45,9 @@ class DefaultClientManager(ClientManager):
 class CookieClientManager(ClientManager):
     _site_name: str  # 绑定的 site_name，需要使用 create_cookie_client_manager 创建 Client_mgr 时绑定
 
+    def __init__(self, site: "Site") -> None:
+        self._site = site
+
     @classmethod
     async def _generate_anonymous_cookie(cls) -> Cookie:
         return Cookie(

--- a/tests/config/test_cookie.py
+++ b/tests/config/test_cookie.py
@@ -30,7 +30,7 @@ async def test_cookie(app: App, init_scheduler):
     client_mgr = cast(CookieClientManager, site.client_mgr)
 
     # 刷新匿名cookie
-    await client_mgr.refresh_anonymous_cookie()
+    await client_mgr.refresh_client()
 
     cookies = await config.get_cookie(site_name=site.name)
     assert len(cookies) == 1

--- a/tests/config/test_cookie.py
+++ b/tests/config/test_cookie.py
@@ -12,6 +12,7 @@ async def test_cookie(app: App, init_scheduler):
 
     from nonebot_bison.platform import site_manager
     from nonebot_bison.config.db_config import config
+    from nonebot_bison.scheduler import scheduler_dict
     from nonebot_bison.types import Target as T_Target
     from nonebot_bison.utils.site import CookieClientManager
     from nonebot_bison.config.utils import DuplicateCookieTargetException
@@ -27,7 +28,7 @@ async def test_cookie(app: App, init_scheduler):
         tags=[],
     )
     site = site_manager["weibo.com"]
-    client_mgr = cast(CookieClientManager, site.client_mgr)
+    client_mgr = cast(CookieClientManager, scheduler_dict[site].client_mgr)
 
     # 刷新匿名cookie
     await client_mgr.refresh_client()

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -153,6 +153,6 @@ async def _clear_db(app: App):
 def _patch_weibo_get_cookie_name(app: App, mocker: MockerFixture):
     from nonebot_bison.platform import weibo
 
-    mocker.patch.object(weibo.WeiboSite, "_get_current_user_name", return_value="test_name")
+    mocker.patch.object(weibo.WeiboClientManager, "_get_current_user_name", return_value="test_name")
     yield
     mocker.stopall()

--- a/tests/platforms/test_bilibili.py
+++ b/tests/platforms/test_bilibili.py
@@ -32,7 +32,7 @@ def bilibili(app: App) -> "Bilibili":
     from nonebot_bison.platform import platform_manager
     from nonebot_bison.platform.bilibili import BilibiliClientManager
 
-    return platform_manager["bilibili"](ProcessContext(BilibiliClientManager(platform_manager["bilibili"].site)))  # type: ignore
+    return platform_manager["bilibili"](ProcessContext(BilibiliClientManager()))  # type: ignore
 
 
 @pytest.fixture

--- a/tests/platforms/test_bilibili.py
+++ b/tests/platforms/test_bilibili.py
@@ -32,7 +32,7 @@ def bilibili(app: App) -> "Bilibili":
     from nonebot_bison.platform import platform_manager
     from nonebot_bison.platform.bilibili import BilibiliClientManager
 
-    return platform_manager["bilibili"](ProcessContext(BilibiliClientManager()))  # type: ignore
+    return platform_manager["bilibili"](ProcessContext(BilibiliClientManager(platform_manager["bilibili"].site)))  # type: ignore
 
 
 @pytest.fixture

--- a/tests/platforms/test_weibo.py
+++ b/tests/platforms/test_weibo.py
@@ -221,7 +221,10 @@ async def test_parse_target(weibo: "Weibo"):
 
 @respx.mock
 async def test_get_cookie_name(weibo: "Weibo"):
+    from nonebot_bison.platform.weibo import WeiboClientManager
+
     router = respx.get("https://m.weibo.cn/setup/nick/detail")
     router.mock(return_value=Response(200, json=get_json("weibo_get-cookie-name.json")))
-    name = await weibo.site.get_cookie_name("{}")
+    weibo_client_mgr = WeiboClientManager()
+    name = await weibo_client_mgr.get_cookie_name("{}")
     assert name == "weibo: [suyiiyii]"


### PR DESCRIPTION
## 尝试解决 `CookieClientManager 和 CookieSite 之间引用过多` 的问题
* 为 `CookieClientManager` 移除了 `_site_name: str` 类属性，添加 `_site: Site` 实例属性
* 添加了 `CookieClientManager` 的 `__init__(self, site: "Site")` 构造方法，构造时传入 `Site` 对象，便于 `CookieClientManager ` 找 `Site`  （修改了 `init_scheduler()` 函数）
* 将 `CookieClientManager`  的 类方法 改为 普通方法
* 弃用 `create_cookie_client_manager()` 方法，改为构造时传入 `Site` 对象

修改过后，

* `CookieSite` 不再需要奇怪的 `create_cookie_client_manager()` 方法去设置 `client_mgr` 属性 ，而是直接设置为 `CookieClientManager`  即可
* `CookieClientManager` 持有对应的 `Site` 对象的引用，方便进行验证 cookie 格式等操作
* `Platform` 通过 `ProcessContext` 对象直接获取 `Client`，不需要接触 `CookieClientManager` 
* 其他情况（例如添加Cookie时），用 `Site` 通过 `scheduler_dict` 找到 `Scheduler`，就可以获取 `Scheduler` 持有的 `CookieClientManager` ，即可进行相关操作
* `CookieSite` 只持有 对应的 `CookieClientManager` 类型，`CookieClientManager` 的实例由  `Scheduler` 创建并持有。`CookieSite` 没有直接调用 `CookieClientManager` 内方法的需求

